### PR TITLE
parser/contact: Change addition order to the end of list

### DIFF
--- a/src/core/parser/contact/contact.c
+++ b/src/core/parser/contact/contact.c
@@ -214,11 +214,14 @@ static inline int skip_name(str *_s)
  */
 int parse_contacts(str *_s, contact_t **_c)
 {
-	contact_t *c;
+	contact_t *c, **head, **last;
 	param_hooks_t hooks;
 	str sv;
 
 	sv = *_s;
+	head = _c;
+	/* Find the last node if not empty and save it
+	 for quick access*/
 
 	while(1) {
 		/* Allocate and clear contact structure */
@@ -298,9 +301,9 @@ int parse_contacts(str *_s, contact_t **_c)
 		_s->len--;
 		trim_leading(_s);
 
-		c->next = *_c;
 		*_c = c;
-		c = NULL;
+		_c = &c->next;
+		c->next = NULL;
 
 		if(_s->len == 0) {
 			LM_ERR("text after comma missing\n");
@@ -318,8 +321,8 @@ error:
 
 ok:
 	c->len = _s->s - c->name.s;
-	c->next = *_c;
 	*_c = c;
+	_c = &c->next;
 	return 0;
 }
 


### PR DESCRIPTION
- Contacts are now added at the end of the list.
- hfl(Contact)[index] is now returning in the correct order.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
